### PR TITLE
Showstopper bug fixes

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -241,7 +241,7 @@ void MediaMenu::floppyNewImage(int i) {
 }
 
 void MediaMenu::floppySelectImage(int i, bool wp) {
-    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "All images (*.0??;*.1??;*.??0;*.86F;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.JSON;*.TD0;*.*FD?;*.MFM;*.XDF);;Advanced sector images (*.IMD;*.JSON;*.TD0);;Basic sector images (*.0??;*.1??;*.??0;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.XDF;*.*FD?);;Flux images (*.FDI);;Surface images (*.86F;*.MFM);;All files (*)");
+    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "All images (*.0?? *.1?? *.??0 *.86F *.BIN *.CQ? *.D?? *.FLP *.HDM *.IM? *.JSON *.TD0 *.*FD? *.MFM *.XDF);;Advanced sector images (*.IMD *.JSON *.TD0);;Basic sector images (*.0?? *.1?? *.??0 *.BIN *.CQ? *.D?? *.FLP *.HDM *.IM? *.XDF *.*FD?);;Flux images (*.FDI);;Surface images (*.86F *.MFM);;All files (*)");
     floppyMount(i, filename, wp);
 }
 
@@ -304,7 +304,7 @@ void MediaMenu::cdromMount(int i) {
     QString dir;
     QFileInfo fi(cdrom[i].image_path);
 
-    auto filename = QFileDialog::getOpenFileName(parentWidget, "CD-ROM images (*.ISO;*.CUE)\0*.ISO;*.CUE\0All files (*.*)\0*.*\0", fi.canonicalPath());
+    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "CD-ROM images (*.ISO *.CUE *.iso *.cue);;All files (*)");
     if (filename.isEmpty()) {
         auto* imageMenu = dynamic_cast<QAction*>(cdromMenus[i]->children()[cdromImagePos]);
         imageMenu->setChecked(false);
@@ -386,7 +386,7 @@ void MediaMenu::zipNewImage(int i) {
 }
 
 void MediaMenu::zipSelectImage(int i, bool wp) {
-    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "ZIP images (*.im?;*.zdi);;All files (*)");
+    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "ZIP images (*.im? *.zdi *.IM? *.ZDI);;All files (*)");
     zipMount(i, filename, wp);
 }
 
@@ -474,7 +474,7 @@ void MediaMenu::moNewImage(int i) {
 }
 
 void MediaMenu::moSelectImage(int i, bool wp) {
-    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "MO images (*.im?;*.mdi);;All files (*)");
+    auto filename = QFileDialog::getOpenFileName(parentWidget, "Open", QString(), "MO images (*.im? *.mdi *.IM? *.MDI);;All files (*)");
     moMount(i, filename, wp);
 }
 

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -13,7 +13,14 @@
 #include "qt_settingsotherremovable.hpp"
 #include "qt_settingsotherperipherals.hpp"
 
+extern "C"
+{
+#include <86box/86box.h>
+}
+
 #include <QDebug>
+#include <QMessageBox>
+#include <QCheckBox>
 
 class SettingsModel : public QAbstractListModel {
 public:
@@ -128,4 +135,24 @@ void Settings::save() {
     floppyCdrom->save();
     otherRemovable->save();
     otherPeripherals->save();
+}
+
+void Settings::accept()
+{
+    if (confirm_save)
+    {
+        QMessageBox questionbox(QMessageBox::Icon::Question, "86Box", "Do you want to save the settings?\n\nThis will hard reset the emulated machine.", QMessageBox::Save | QMessageBox::Cancel, this);
+        QCheckBox *chkbox = new QCheckBox("Do not ask me again");
+        questionbox.setCheckBox(chkbox);
+        chkbox->setChecked(!confirm_save);
+        QObject::connect(chkbox, &QCheckBox::stateChanged, [](int state) {
+            confirm_save = (state == Qt::CheckState::Unchecked);
+        });
+        questionbox.exec();
+        if (questionbox.result() == QMessageBox::Cancel) {
+            confirm_save = true;
+            return;
+        }
+    }
+    QDialog::accept();
 }

--- a/src/qt/qt_settings.hpp
+++ b/src/qt/qt_settings.hpp
@@ -28,6 +28,9 @@ public:
     ~Settings();
      void save();
 
+protected slots:
+     void accept() override;
+
 private:
     Ui::Settings *ui;
     SettingsMachine* machine;

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -49,7 +49,7 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent) :
             }
 
             int row = Models::AddEntry(model, name, d);
-            if (d == isartc_type) {
+            if (d == isamem_type[c]) {
                 selectedRow = row;
             }
             ++d;


### PR DESCRIPTION
* Fix files not appearing because of filter strings being wrong
* Implement settings save prompt
* Fix another show-stopper bug where the cards wouldn't show their true selections when Other Peripherals settings page was opened