### PR TITLE
Blitting improvements

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -35,11 +35,11 @@ void HardwareRenderer::setRenderType(RenderType type) {
     setFormat(format);
 }
 
-void HardwareRenderer::onBlit(const QImage& img, int x, int y, int w, int h, std::atomic_flag* in_use) {
-    image = img;
+void HardwareRenderer::onBlit(const std::unique_ptr<uint8_t>* img, int x, int y, int w, int h, std::atomic_flag* in_use) {
+    memcpy(image.bits(), img->get(), 2048 * 2048 * 4);
+    in_use->clear();
     source.setRect(x, y, w, h);
     update();
-    in_use->clear();
 }
 
 void HardwareRenderer::resizeEvent(QResizeEvent *event) {

--- a/src/qt/qt_hardwarerenderer.hpp
+++ b/src/qt/qt_hardwarerenderer.hpp
@@ -47,7 +47,7 @@ public:
     void setRenderType(RenderType type);
 
 public slots:
-    void onBlit(const QImage& img, int, int, int, int, std::atomic_flag* in_use);
+    void onBlit(const std::unique_ptr<uint8_t>* img, int, int, int, int, std::atomic_flag* in_use);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -901,9 +901,7 @@ void MainWindow::on_actionFullscreen_triggered() {
         video_fullscreen = 1;
     }
 
-    auto widget = ui->stackedWidget->currentWidget();
-    auto rc = dynamic_cast<RendererCommon*>(widget);
-    rc->onResize(widget->width(), widget->height());
+    ui->stackedWidget->switchRenderer((RendererStack::Renderer)vid_api);
 }
 
 void MainWindow::getTitle_(wchar_t *title)

--- a/src/qt/qt_renderercomon.cpp
+++ b/src/qt/qt_renderercomon.cpp
@@ -18,9 +18,6 @@ void RendererCommon::onPaint(QPaintDevice* device) {
     painter.fillRect(0, 0, device->width(), device->height(), QColorConstants::Black);
     painter.setCompositionMode(QPainter::CompositionMode_Plus);
     painter.drawImage(destination, image, source);
-    // "release" image, reducing it's refcount, so renderstack::blit()
-    // won't have to reallocate
-    image = QImage();
 }
 
 static void integer_scale(double *d, double *g) {

--- a/src/qt/qt_renderercomon.hpp
+++ b/src/qt/qt_renderercomon.hpp
@@ -14,6 +14,6 @@ public:
 protected:
     void onPaint(QPaintDevice* device);
 
-    QImage image;
+    QImage image{QSize(2048, 2048), QImage::Format_RGB32};
     QRect source, destination;
 };

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 #include <atomic>
+#include <array>
 
 namespace Ui {
 class RendererStack;
@@ -42,7 +43,7 @@ public:
     void switchRenderer(Renderer renderer);
 
 signals:
-    void blitToRenderer(const QImage& img, int, int, int, int, std::atomic_flag* in_use);
+    void blitToRenderer(const std::unique_ptr<uint8_t>* img, int, int, int, int, std::atomic_flag* in_use);
 
 public slots:
     void blit(int x, int y, int w, int h);
@@ -59,11 +60,8 @@ private:
 
     int x, y, w, h, sx, sy, sw, sh;
 
-    // always have a qimage available for writing, which is _probably_ unused
-    // worst case - it will just get reallocated because it's refcounter is > 1
-    // when calling bits();
     int currentBuf = 0;
-    QVector<QImage> imagebufs;
+    std::array<std::unique_ptr<uint8_t>, 2> imagebufs;
 
     std::unique_ptr<QWidget> current;
 

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -7,11 +7,11 @@ void SoftwareRenderer::paintEvent(QPaintEvent *event) {
     onPaint(this);
 }
 
-void SoftwareRenderer::onBlit(const QImage& img, int x, int y, int w, int h, std::atomic_flag* in_use) {
-    image = img;
+void SoftwareRenderer::onBlit(const std::unique_ptr<uint8_t>* img, int x, int y, int w, int h, std::atomic_flag* in_use) {
+    memcpy(image.bits(), img->get(), 2048 * 2048 * 4);
+    in_use->clear();
     source.setRect(x, y, w, h);
     update();
-    in_use->clear();
 }
 
 void SoftwareRenderer::resizeEvent(QResizeEvent *event) {

--- a/src/qt/qt_softwarerenderer.hpp
+++ b/src/qt/qt_softwarerenderer.hpp
@@ -13,7 +13,7 @@ public:
 
     void paintEvent(QPaintEvent *event) override;
 public slots:
-    void onBlit(const QImage& img, int, int, int, int, std::atomic_flag* in_use);
+    void onBlit(const std::unique_ptr<uint8_t>* img, int, int, int, int, std::atomic_flag* in_use);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
* Use a single QImage copy for actual drawing
* Use std::array and std::unique_ptr for image buffers
* Signal immediately after copying the buffer to internal image
* Fix crash on fullscreen switches.
