### PR TITLE
Qt UI improvements

### DIFF
--- a/src/qt/qt.c
+++ b/src/qt/qt.c
@@ -27,9 +27,17 @@ wchar_t* plat_get_string(int i)
     case IDS_2077:
         return L"Click to capture mouse.";
     case IDS_2078:
+#ifdef _WIN32
+        return L"Press F8+F12 to release mouse";
+#else
         return L"Press CTRL-END to release mouse";
+#endif
     case IDS_2079:
+#ifdef _WIN32
+        return L"Press F8+F12 or middle button to release mouse";
+#else
         return L"Press CTRL-END or middle button to release mouse";
+#endif
     case IDS_2080:
         return L"Failed to initialize FluidSynth";
     case IDS_4099:

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -339,7 +339,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->cassette.label = std::make_unique<ClickableLabel>();
         d->cassette.setEmpty(QString(cassette_fname).isEmpty());
         connect((ClickableLabel*)d->cassette.label.get(), &ClickableLabel::clicked, [this](QPoint pos) {
-            MediaMenu::ptr->cassetteMenu->popup(pos);
+            MediaMenu::ptr->cassetteMenu->popup(pos - QPoint(0, MediaMenu::ptr->cassetteMenu->sizeHint().height()));
         });
         d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
         sbar->addWidget(d->cassette.label.get());
@@ -347,10 +347,10 @@ void MachineStatus::refresh(QStatusBar* sbar) {
 
     if (machine_has_cartridge(machine)) {
         for (int i = 0; i < 2; ++i) {
-            d->cartridge[i].label = std::make_unique<QLabel>();
+            d->cartridge[i].label = std::make_unique<ClickableLabel>();
             d->cartridge[i].setEmpty(QString(cart_fns[i]).isEmpty());
             connect((ClickableLabel*)d->cartridge[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
-                MediaMenu::ptr->cartridgeMenus[i]->popup(pos);
+                MediaMenu::ptr->cartridgeMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->cartridgeMenus[i]->sizeHint().height()));
             });
             d->cartridge[i].label->setToolTip(MediaMenu::ptr->cartridgeMenus[i]->title());
             sbar->addWidget(d->cartridge[i].label.get());
@@ -370,7 +370,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->fdd[i].setEmpty(QString(floppyfns[i]).isEmpty());
         d->fdd[i].setActive(false);
         connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
-            MediaMenu::ptr->floppyMenus[i]->popup(pos);
+            MediaMenu::ptr->floppyMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->floppyMenus[i]->sizeHint().height()));
         });
         d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->title());
         sbar->addWidget(d->fdd[i].label.get());
@@ -381,7 +381,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->cdrom[i].setEmpty(cdrom[i].host_drive != 200 || QString(cdrom[i].image_path).isEmpty());
         d->cdrom[i].setActive(false);
         connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
-            MediaMenu::ptr->cdromMenus[i]->popup(pos);
+            MediaMenu::ptr->cdromMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->cdromMenus[i]->sizeHint().height()));
         });
         d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->title());
         sbar->addWidget(d->cdrom[i].label.get());
@@ -392,7 +392,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->zip[i].setEmpty(QString(zip_drives[i].image_path).isEmpty());
         d->zip[i].setActive(false);
         connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
-            MediaMenu::ptr->zipMenus[i]->popup(pos);
+            MediaMenu::ptr->zipMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->zipMenus[i]->sizeHint().height()));
         });
         d->zip[i].label->setToolTip(MediaMenu::ptr->zipMenus[i]->title());
         sbar->addWidget(d->zip[i].label.get());
@@ -403,7 +403,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->mo[i].setEmpty(QString(mo_drives[i].image_path).isEmpty());
         d->mo[i].setActive(false);
         connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
-            MediaMenu::ptr->moMenus[i]->popup(pos);
+            MediaMenu::ptr->moMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->moMenus[i]->sizeHint().height()));
         });
         d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->title());
         sbar->addWidget(d->mo[i].label.get());

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -252,7 +252,7 @@ MainWindow::MainWindow(QWidget *parent) :
         ui->actionChange_contrast_for_monochrome_display->setChecked(true);
     }
 
-#ifdef Q_OS_WINDOWS
+#if defined Q_OS_WINDOWS || defined Q_OS_MACOS
     /* Make the option visible only if ANGLE is loaded. */
     ui->actionHardware_Renderer_OpenGL_ES->setVisible(QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES);
 #endif

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -57,6 +57,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     ui->stackedWidget->setMouseTracking(true);
     statusBar()->setVisible(!hide_status_bar);
+    statusBar()->setStyleSheet("QStatusBar::item {border: None;}");
 
     this->setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
 
@@ -252,8 +253,8 @@ MainWindow::MainWindow(QWidget *parent) :
     }
 
 #ifdef Q_OS_WINDOWS
-    /* qt opengles doesn't work (yet?) so hide the menu option */
-    ui->actionHardware_Renderer_OpenGL_ES->setVisible(false);
+    /* Make the option visible only if ANGLE is loaded. */
+    ui->actionHardware_Renderer_OpenGL_ES->setVisible(QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES);
 #endif
 
     setFocusPolicy(Qt::StrongFocus);
@@ -890,10 +891,11 @@ uint16_t x11_keycode_to_keysym(uint32_t keycode)
 
 void MainWindow::on_actionFullscreen_triggered() {
     if (video_fullscreen > 0) {
+        showNormal();
         ui->menubar->show();
         ui->statusbar->show();
-        showNormal();
         video_fullscreen = 0;
+        setGeometry(geometry());
     } else {
         ui->menubar->hide();
         ui->statusbar->hide();

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -112,6 +112,7 @@ Settings::Settings(QWidget *parent) :
     connect(machine, &SettingsMachine::currentMachineChanged, sound, &SettingsSound::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, network, &SettingsNetwork::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, storageControllers, &SettingsStorageControllers::onCurrentMachineChanged);
+    connect(machine, &SettingsMachine::currentMachineChanged, otherPeripherals, &SettingsOtherPeripherals::onCurrentMachineChanged);
 
     connect(ui->listView->selectionModel(), &QItemSelectionModel::currentChanged, this, [this](const QModelIndex &current, const QModelIndex &previous) {
         ui->stackedWidget->setCurrentIndex(current.row());

--- a/src/qt/qt_settingsotherperipherals.hpp
+++ b/src/qt/qt_settingsotherperipherals.hpp
@@ -16,6 +16,10 @@ public:
     ~SettingsOtherPeripherals();
 
     void save();
+
+public slots:
+    void onCurrentMachineChanged(int machineId);
+
 private slots:
     void on_pushButtonConfigureCard4_clicked();
     void on_comboBoxCard4_currentIndexChanged(int index);
@@ -30,6 +34,7 @@ private slots:
 
 private:
     Ui::SettingsOtherPeripherals *ui;
+    int machineId{0};
 };
 
 #endif // QT_SETTINGSOTHERPERIPHERALS_HPP


### PR DESCRIPTION
* Port https://github.com/86Box/86Box/commit/209b5d9cd1b5ec63fca324aaea8f4dcc1160e21c to Qt UI
* Remove dividers from status bar
* Make OpenGL ES available as an option only if ANGLE is used
* Force a resize when returning from fullscreen
* Fix wrong title bar text for Windows
* Menus invoked from status bar now appear inside the window