### PR TITLE
Fix OpenGL ES renderer not actually creating OpenGL ES contexts

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -57,6 +57,11 @@ void HardwareRenderer::initializeGL()
 
     m_prog->bind();
     m_prog->setUniformValue("texture", 0);
+
+    pclog("OpenGL vendor: %s\n", glGetString(GL_VENDOR));
+    pclog("OpenGL renderer: %s\n", glGetString(GL_RENDERER));
+    pclog("OpenGL version: %s\n", glGetString(GL_VERSION));
+    pclog("OpenGL shader language version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
 }
 
 void HardwareRenderer::paintGL() {

--- a/src/qt/qt_hardwarerenderer.hpp
+++ b/src/qt/qt_hardwarerenderer.hpp
@@ -33,17 +33,23 @@ private:
     QOpenGLShaderProgram* m_prog;
     QOpenGLTextureBlitter* m_blt;
 public:
+    enum class RenderType {
+        OpenGL,
+        OpenGLES,
+    };
     void resizeGL(int w, int h) override;
     void initializeGL() override;
     void paintGL() override;
-    HardwareRenderer(QWidget* parent = nullptr)
+    HardwareRenderer(QWidget* parent = nullptr, RenderType rtype = RenderType::OpenGL)
     : QOpenGLWindow(QOpenGLWindow::NoPartialUpdate, parent->windowHandle()), QOpenGLFunctions()
     {
         setMinimumSize(QSize(16, 16));
         setFlags(Qt::FramelessWindowHint);
         parentWidget = parent;
+        setRenderType(rtype);
 
         m_context = new QOpenGLContext();
+        m_context->setFormat(format());
         m_context->create();
     }
     ~HardwareRenderer()
@@ -52,10 +58,7 @@ public:
         if (m_blt) m_blt->destroy();
     }
 
-    enum class RenderType {
-        OpenGL,
-        OpenGLES,
-    };
+
     void setRenderType(RenderType type);
 
 public slots:

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -316,8 +316,7 @@ plat_mmap(size_t size, uint8_t executable)
 #else
     void *ret = mmap(0, size, PROT_READ | PROT_WRITE | (executable ? PROT_EXEC : 0), MAP_ANON | MAP_PRIVATE, 0, 0);
 #endif
-    auto retval = *reinterpret_cast<int*>(ret);
-    return (retval < 0) ? nullptr : ret;
+    return (ret == MAP_FAILED) ? nullptr : ret;
 #endif
 }
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -185,16 +185,14 @@ void RendererStack::switchRenderer(Renderer renderer) {
         this->createWinId();
         auto hw = new HardwareRenderer(this);
         connect(this, &RendererStack::blitToRenderer, hw, &HardwareRenderer::onBlit, Qt::QueuedConnection);
-        hw->setRenderType(HardwareRenderer::RenderType::OpenGL);
         current.reset(this->createWindowContainer(hw, this));
         break;
     }
     case Renderer::OpenGLES:
     {
         this->createWinId();
-        auto hw = new HardwareRenderer(this);
+        auto hw = new HardwareRenderer(this, HardwareRenderer::RenderType::OpenGLES);
         connect(this, &RendererStack::blitToRenderer, hw, &HardwareRenderer::onBlit, Qt::QueuedConnection);
-        hw->setRenderType(HardwareRenderer::RenderType::OpenGLES);
         current.reset(this->createWindowContainer(hw, this));
         break;
     }


### PR DESCRIPTION
This also adds some logging about the OpenGL hardware it is running on.